### PR TITLE
WIP: widgetify of property boxes

### DIFF
--- a/wradvis/config.py
+++ b/wradvis/config.py
@@ -13,19 +13,16 @@
 from configparser import ConfigParser
 import os
 
-# Initialise default configuration object
 
+# Initialise default configuration object
 def init_conf():
 
     conf = ConfigParser()
 
     conf["dirs"] = {"data": os.path.join(os.getcwd(), "data/rw/20160529") }
+    conf["source"] = {"product": "RW", "loc": ""}
     conf["vis"] = {"clim": (0,50)}
 
     return(conf)
 
 conf = init_conf()
-
-
-
-

--- a/wradvis/config.py
+++ b/wradvis/config.py
@@ -21,7 +21,7 @@ def init_conf():
 
     conf["dirs"] = {"data": os.path.join(os.getcwd(), "data/rw/20160529") }
     conf["source"] = {"product": "RW", "loc": ""}
-    conf["vis"] = {"clim": (0,50)}
+    conf["vis"] = {"cmax": 50, "cmin": 0}
 
     return(conf)
 

--- a/wradvis/glcanvas.py
+++ b/wradvis/glcanvas.py
@@ -175,7 +175,6 @@ class RadolanCanvas(SceneCanvas):
         self.text = []
         i = 0
         for p, n in zip(pos_scene, cnameList):
-            print(i, p, n)
             m, t = self.create_marker(i, p, n)
             self.markers.append(m)
             self.text.append(t)
@@ -281,7 +280,7 @@ class DXCanvas(SceneCanvas):
     def on_mouse_move(self, event):
         tr = self.scene.node_transform(self.image)
         point = tr.map(event.pos)[:2]
-        # we should actually move this into PTransform in the future
+        # todo: we should actually move this into PTransform in the future
         point[0] += np.pi
         point[0] = np.rad2deg(point[0])
         self._mouse_position = point

--- a/wradvis/glcanvas.py
+++ b/wradvis/glcanvas.py
@@ -185,7 +185,7 @@ class RadolanCanvas(SceneCanvas):
         point = self.scene.node_transform(self.image).map(event.pos)[:2]
         self._mouse_position = point
         # emit signal
-        self.mouse_moved()
+        self.mouse_moved(event)
 
     def on_mouse_press(self, event):
         self.view.interactive = False

--- a/wradvis/glcanvas.py
+++ b/wradvis/glcanvas.py
@@ -26,7 +26,7 @@ class ColorbarCanvas(SceneCanvas):
         super(ColorbarCanvas, self).__init__(keys='interactive', **kwargs)
 
         # set size ov Canvas
-        self.size = 50, 450
+        self.size = 60, 450
 
         # unfreeze needed to add more elements
         self.unfreeze()
@@ -55,7 +55,7 @@ class ColorbarCanvas(SceneCanvas):
 
         # add transform to Colorbar
         self.cbar.transform = STTransform(scale=(1, 1, 1),
-                                          translate=(20, 250, 0.5))
+                                          translate=(20, 225, 0.5))
 
         # whiten label and ticks
         self.cbar.label.color = 'white'
@@ -253,6 +253,7 @@ class PolarTransform(BaseTransform):
         return ret
 
 
+# Todo: The Orientation of the ppi is not yet correct
 class DXCanvas(SceneCanvas):
     def __init__(self, **kwargs):
         super(DXCanvas, self).__init__(keys='interactive', **kwargs)
@@ -372,3 +373,4 @@ class RadolanWidget(QtGui.QWidget):
 
     def set_clim(self, clim):
         self.canvas.image.clim = clim
+        self.cbar.cbar.clim = clim

--- a/wradvis/glcanvas.py
+++ b/wradvis/glcanvas.py
@@ -46,7 +46,7 @@ class ColorbarCanvas(SceneCanvas):
         self.cbar = ColorBar(center_pos=(0, 10),
                              size=np.array([400, 20]),
                              cmap=cmap,
-                             clim=conf["vis"]["clim"],
+                             clim=(conf["vis"]["cmin"], conf["vis"]["cmax"]),
                              label_str='measurement units',
                              orientation='right',
                              border_width=1,
@@ -281,6 +281,8 @@ class DXCanvas(SceneCanvas):
                            clim=(-32.5, 95),
                            parent=self.view.scene)
 
+        # Polar Transform takes care of making PPI from data array
+        # the translation moves the image to have the ppi centered
         self.image.transform = (STTransform(translate=(128, 128, 0)) *
                                 PolarTransform())
 
@@ -292,6 +294,7 @@ class DXCanvas(SceneCanvas):
         self.events.mouse_double_click.block()
 
         # create PanZoomCamera
+        # the camera should zoom to the ppi "bounding box"
         self.cam = PanZoomCamera(name="PanZoom",
                                  rect=Rect(0, 0, 256, 256),
                                  aspect=1,
@@ -366,3 +369,6 @@ class RadolanWidget(QtGui.QWidget):
     def set_data(self, data):
         self.canvas.image.set_data(data)
         self.canvas.update()
+
+    def set_clim(self, clim):
+        self.canvas.image.clim = clim

--- a/wradvis/gui.py
+++ b/wradvis/gui.py
@@ -46,7 +46,7 @@ class MainWindow(QtGui.QMainWindow):
         # add PropertiesWidget
         self.props = PropertiesWidget()
         self.props.signal_slider_changed.connect(self.slider_changed)
-        self.props.signal_playpause_changed.connect(self.start_stop)
+        self.props.mediabox.signal_playpause_changed.connect(self.start_stop)
         self.props.signal_speed_changed.connect(self.speed)
 
         # add Horizontal Splitter and the three widgets
@@ -61,10 +61,10 @@ class MainWindow(QtGui.QMainWindow):
         self.slider_changed()
 
     def reload(self):
-        if self.props.slider.value() == self.props.slider.maximum():
-            self.props.slider.setValue(1)
+        if self.props.mediabox.slider.value() == self.props.mediabox.slider.maximum():
+            self.props.mediabox.slider.setValue(1)
         else:
-            self.props.slider.setValue(self.props.slider.value() + 1)
+            self.props.mediabox.slider.setValue(self.props.mediabox.slider.value() + 1)
 
     def start_stop(self):
         if self.timer.isActive():
@@ -73,7 +73,7 @@ class MainWindow(QtGui.QMainWindow):
             self.timer.start()
 
     def speed(self):
-        self.timer.setInterval(self.props.speed.value())
+        self.timer.setInterval(self.props.mediabox.speed.value())
 
     def slider_changed(self):
         try:
@@ -82,8 +82,8 @@ class MainWindow(QtGui.QMainWindow):
             print("Could not read any data.")
         else:
             scantime = self.meta['datetime']
-            self.props.sliderLabel.setText(scantime.strftime("%H:%M"))
-            self.props.date.setText(scantime.strftime("%Y-%m-%d"))
+            self.props.mediabox.sliderLabel.setText(scantime.strftime("%H:%M"))
+            self.props.mediabox.date.setText(scantime.strftime("%Y-%m-%d"))
             self.iwidget.set_data(self.data)
 
     def mouse_moved(self, event):

--- a/wradvis/gui.py
+++ b/wradvis/gui.py
@@ -143,6 +143,9 @@ class MainWindow(QtGui.QMainWindow):
 
             else:
                 self.data, self.meta = utils.read_radolan(self.props.filelist[self.props.actualFrame])
+                if self.props.product == 'RX':
+                    self.data = (self.data / 2) - 32.5
+
         except IndexError:
             print("Could not read any data.")
         else:

--- a/wradvis/gui.py
+++ b/wradvis/gui.py
@@ -133,7 +133,7 @@ class MainWindow(QtGui.QMainWindow):
 
     def slider_changed(self):
         try:
-            # switching happens here,
+            # Todo: switching happens here,
             # but we should just use a common reading function, where the
             # underlying wradlib function is exchanged on switching data
             # format
@@ -145,7 +145,6 @@ class MainWindow(QtGui.QMainWindow):
                 self.data, self.meta = utils.read_radolan(self.props.filelist[self.props.actualFrame])
                 if self.props.product == 'RX':
                     self.data = (self.data / 2) - 32.5
-
         except IndexError:
             print("Could not read any data.")
         else:

--- a/wradvis/gui.py
+++ b/wradvis/gui.py
@@ -15,7 +15,6 @@ from wradvis import utils
 from wradvis.config import conf
 
 
-
 class MainWindow(QtGui.QMainWindow):
 
     def __init__(self, parent=None):
@@ -41,14 +40,10 @@ class MainWindow(QtGui.QMainWindow):
         self.swapper.append(self.mwidget)
 
         # need some tracer for the mouse position
-        #self.rwidget.canvas.mouse_moved.connect(self.mouse_moved)
         self.rwidget.canvas.key_pressed.connect(self.keyPressEvent)
 
         # add PropertiesWidget
         self.props = Properties()
-        #self.props.signal_slider_changed.connect(self.slider_changed)
-
-        #self.props.signal_speed_changed.connect(self.speed)
 
         # add Horizontal Splitter and the three widgets
         self.splitter = QtGui.QSplitter(QtCore.Qt.Horizontal)
@@ -64,7 +59,7 @@ class MainWindow(QtGui.QMainWindow):
         self.connect_signals()
 
         # finish init
-        self.slider_changed()
+        self.props.update_props()
 
     def connect_signals(self):
         self.mediabox.signal_playpause_changed.connect(self.start_stop)

--- a/wradvis/gui.py
+++ b/wradvis/gui.py
@@ -162,6 +162,7 @@ class MainWindow(QtGui.QMainWindow):
             self.swapper = self.swapper[::-1]
             self.iwidget = self.swapper[0]
             self.swapper[0].show()
+            self.swapper[0].setFocus()
             self.swapper[1].hide()
 
 

--- a/wradvis/gui.py
+++ b/wradvis/gui.py
@@ -132,7 +132,9 @@ class MainWindow(QtGui.QMainWindow):
 
     def slider_changed(self):
         try:
-            self.data, self.meta = utils.read_radolan(self.props.filelist[self.props.actualFrame])
+            self.data, self.meta = utils.read_dx(
+                self.props.filelist[self.props.actualFrame])
+            #self.data, self.meta = utils.read_radolan(self.props.filelist[self.props.actualFrame])
         except IndexError:
             print("Could not read any data.")
         else:

--- a/wradvis/gui.py
+++ b/wradvis/gui.py
@@ -10,9 +10,10 @@ from PyQt4 import QtGui, QtCore
 # other wradvis imports
 from wradvis.glcanvas import RadolanWidget
 from wradvis.mplcanvas import MplWidget
-from wradvis.properties import PropertiesWidget
+from wradvis.properties import Properties, MediaBox, SourceBox, MouseBox
 from wradvis import utils
 from wradvis.config import conf
+
 
 
 class MainWindow(QtGui.QMainWindow):
@@ -40,31 +41,90 @@ class MainWindow(QtGui.QMainWindow):
         self.swapper.append(self.mwidget)
 
         # need some tracer for the mouse position
-        self.rwidget.canvas.mouse_moved.connect(self.mouse_moved)
+        #self.rwidget.canvas.mouse_moved.connect(self.mouse_moved)
         self.rwidget.canvas.key_pressed.connect(self.keyPressEvent)
 
         # add PropertiesWidget
-        self.props = PropertiesWidget()
-        self.props.signal_slider_changed.connect(self.slider_changed)
-        self.props.mediabox.signal_playpause_changed.connect(self.start_stop)
-        self.props.signal_speed_changed.connect(self.speed)
+        self.props = Properties()
+        #self.props.signal_slider_changed.connect(self.slider_changed)
+
+        #self.props.signal_speed_changed.connect(self.speed)
 
         # add Horizontal Splitter and the three widgets
         self.splitter = QtGui.QSplitter(QtCore.Qt.Horizontal)
-        self.splitter.addWidget(self.props)
         self.splitter.addWidget(self.swapper[0])
         self.splitter.addWidget(self.swapper[1])
         self.swapper[1].hide()
         self.setCentralWidget(self.splitter)
 
+        self.createActions()
+        self.createMenus()
+        self.createDockWindows()
+
+        self.connect_signals()
+
         # finish init
         self.slider_changed()
 
+    def connect_signals(self):
+        self.mediabox.signal_playpause_changed.connect(self.start_stop)
+        self.mediabox.signal_slider_changed.connect(self.slider_changed)
+        self.mediabox.signal_speed_changed.connect(self.speed)
+
+    def createActions(self):
+        # Set data directory
+        self.setDataDir = QtGui.QAction("&Set data directory", self,
+                                        statusTip='Set data directory',
+                                        triggered=self.props.set_datadir)
+        # Open project (configuration)
+        self.openConf = QtGui.QAction("&Open project", self,
+                                      shortcut="Ctrl+O",
+                                      statusTip='Open project',
+                                      triggered=self.props.open_conf)
+
+        # Save project (configuration)
+        self.saveConf = QtGui.QAction("&Save project", self,
+                                      shortcut="Ctrl+S",
+                                      statusTip='Save project',
+                                      triggered=self.props.save_conf)
+
+    def createMenus(self):
+        self.fileMenu = self.menuBar().addMenu("&File")
+        self.fileMenu.addAction(self.setDataDir)
+        self.fileMenu.addAction(self.openConf)
+        self.fileMenu.addAction(self.saveConf)
+
+        self.toolsMenu = self.menuBar().addMenu('&Tools')
+
+        self.helpMenu = self.menuBar().addMenu('&Help')
+
+    def createDockWindows(self):
+        dock = QtGui.QDockWidget("Radar Source Data", self)
+        dock.setAllowedAreas(QtCore.Qt.RightDockWidgetArea)
+        self.sourcebox = SourceBox(self)
+        dock.setWidget(self.sourcebox)
+        self.addDockWidget(QtCore.Qt.RightDockWidgetArea, dock)
+        self.toolsMenu.addAction(dock.toggleViewAction())
+
+        dock = QtGui.QDockWidget("Media Handling", self)
+        dock.setAllowedAreas(QtCore.Qt.RightDockWidgetArea)
+        self.mediabox = MediaBox(self)
+        dock.setWidget(self.mediabox)
+        self.addDockWidget(QtCore.Qt.RightDockWidgetArea, dock)
+        self.toolsMenu.addAction(dock.toggleViewAction())
+
+        dock = QtGui.QDockWidget("Mouse Interaction", self)
+        dock.setAllowedAreas(QtCore.Qt.RightDockWidgetArea)
+        self.mousebox = MouseBox(self)
+        dock.setWidget(self.mousebox)
+        self.addDockWidget(QtCore.Qt.RightDockWidgetArea, dock)
+        self.toolsMenu.addAction(dock.toggleViewAction())
+
     def reload(self):
-        if self.props.mediabox.slider.value() == self.props.mediabox.slider.maximum():
-            self.props.mediabox.slider.setValue(1)
+        if self.mediabox.data.value() == self.mediabox.data.maximum():
+            self.mediabox.data.setValue(1)
         else:
-            self.props.mediabox.slider.setValue(self.props.mediabox.slider.value() + 1)
+            self.mediabox.data.setValue(self.mediabox.data.value() + 1)
 
     def start_stop(self):
         if self.timer.isActive():
@@ -73,7 +133,7 @@ class MainWindow(QtGui.QMainWindow):
             self.timer.start()
 
     def speed(self):
-        self.timer.setInterval(self.props.mediabox.speed.value())
+        self.timer.setInterval(self.mediabox.speed.value())
 
     def slider_changed(self):
         try:
@@ -82,12 +142,9 @@ class MainWindow(QtGui.QMainWindow):
             print("Could not read any data.")
         else:
             scantime = self.meta['datetime']
-            self.props.mediabox.sliderLabel.setText(scantime.strftime("%H:%M"))
-            self.props.mediabox.date.setText(scantime.strftime("%Y-%m-%d"))
+            self.mediabox.sliderLabel.setText(scantime.strftime("%H:%M"))
+            self.mediabox.date.setText(scantime.strftime("%Y-%m-%d"))
             self.iwidget.set_data(self.data)
-
-    def mouse_moved(self, event):
-        self.props.show_mouse(self.rwidget.canvas._mouse_position)
 
     def keyPressEvent(self, event):
         if isinstance(event, QtGui.QKeyEvent):

--- a/wradvis/gui.py
+++ b/wradvis/gui.py
@@ -28,7 +28,7 @@ class MainWindow(QtGui.QMainWindow):
         self.timer.timeout.connect(self.reload)
 
         # initialize RadolanCanvas
-        self.rwidget = RadolanWidget()
+        self.rwidget = RadolanWidget(self)
         self.iwidget = self.rwidget
 
         # initialize MplWidget
@@ -40,10 +40,10 @@ class MainWindow(QtGui.QMainWindow):
         self.swapper.append(self.mwidget)
 
         # need some tracer for the mouse position
-        self.rwidget.canvas.key_pressed.connect(self.keyPressEvent)
+        self.iwidget.canvas.key_pressed.connect(self.keyPressEvent)
 
         # add PropertiesWidget
-        self.props = Properties()
+        self.props = Properties(self)
 
         # add Horizontal Splitter and the three widgets
         self.splitter = QtGui.QSplitter(QtCore.Qt.Horizontal)
@@ -65,6 +65,7 @@ class MainWindow(QtGui.QMainWindow):
         self.mediabox.signal_playpause_changed.connect(self.start_stop)
         self.mediabox.signal_slider_changed.connect(self.slider_changed)
         self.mediabox.signal_speed_changed.connect(self.speed)
+        self.props.signal_props_changed.connect(self.slider_changed)
 
     def createActions(self):
         # Set data directory
@@ -132,9 +133,16 @@ class MainWindow(QtGui.QMainWindow):
 
     def slider_changed(self):
         try:
-            self.data, self.meta = utils.read_dx(
-                self.props.filelist[self.props.actualFrame])
-            #self.data, self.meta = utils.read_radolan(self.props.filelist[self.props.actualFrame])
+            # switching happens here,
+            # but we should just use a common reading function, where the
+            # underlying wradlib function is exchanged on switching data
+            # format
+            if self.props.product == 'DX':
+                self.data, self.meta = utils.read_dx(
+                    self.props.filelist[self.props.actualFrame])
+
+            else:
+                self.data, self.meta = utils.read_radolan(self.props.filelist[self.props.actualFrame])
         except IndexError:
             print("Could not read any data.")
         else:

--- a/wradvis/mplcanvas.py
+++ b/wradvis/mplcanvas.py
@@ -11,7 +11,7 @@ import matplotlib
 matplotlib.use('Qt4Agg')
 
 
-from PyQt4 import QtGui
+from PyQt4 import QtGui, QtCore
 from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.figure import Figure
 from matplotlib.cm import get_cmap
@@ -22,6 +22,8 @@ from wradvis import config
 
 
 class MplCanvas(FigureCanvas):
+
+    mouse_moved = QtCore.pyqtSignal(matplotlib.backend_bases.MouseEvent, name='mouse_moved')
 
     def __init__(self):#, parent, props):
         # plot definition
@@ -52,6 +54,7 @@ class MplCanvas(FigureCanvas):
         self.ax.set_aspect('equal')
         self.ax.set_xlim([grid[..., 0].min(), grid[..., 0].max()])
         self.ax.set_ylim([grid[..., 1].min(), grid[..., 1].max()])
+        self._mouse_position = None
 
         self.create_cities()
 
@@ -73,6 +76,7 @@ class MplCanvas(FigureCanvas):
                              horizontalalignment='right',
                              verticalalignment='top')
         self.mpl_connect('pick_event', self.onpick_cities)
+        self.mpl_connect('motion_notify_event', self.on_move)
 
     def onpick_cities(self, event):
         artist = event.artist
@@ -94,14 +98,45 @@ class MplCanvas(FigureCanvas):
     def on_key_press(self, event):
         self.key_pressed(event)
 
+    def on_move(self, event):
+        if event.inaxes:
+            ax = event.inaxes  # the axes instance
+            print('data coords %f %f' % (event.xdata, event.ydata))
+            self._mouse_position = np.array([event.xdata, event.ydata])
+            self.mouse_moved.emit(event)
+
 
 class MplWidget(QtGui.QWidget):
     def __init__(self):
         QtGui.QWidget.__init__(self)
-        self.canvas = MplCanvas()
-        self.vbl = QtGui.QVBoxLayout()
-        self.vbl.addWidget(self.canvas)
-        self.setLayout(self.vbl)
+
+        self.rcanvas = MplCanvas()
+        self.pcanvas = MplCanvas()
+
+        self.canvas = self.rcanvas
+
+        # canvas swapper
+        self.swapper = {}
+        self.swapper['R'] = self.rcanvas
+        self.swapper['P'] = self.pcanvas
+
+        #self.splitter = QtGui.QSplitter(QtCore.Qt.Horizontal)
+        #self.splitter.addWidget(self.swapper['R'])
+        #self.splitter.addWidget(self.swapper['P'])
+        #self.swapper['P'].hide()
+
+        # stretchfactors for correct splitter behaviour
+        #self.splitter.setStretchFactor(0, 1)
+        #self.splitter.setStretchFactor(1, 1)
+        #self.splitter.setStretchFactor(2, 0)
+        self.hbl = QtGui.QHBoxLayout()
+        self.hbl.addWidget(self.swapper['R'])
+        self.hbl.addWidget(self.swapper['P'])
+        self.setLayout(self.hbl)
+        self.swapper['P'].hide()
+        #self.vbl = QtGui.QVBoxLayout()
+        #self.vbl.addWidget(self.canvas)
+        #self.setLayout(self.vbl)
 
     def set_data(self, data):
         self.canvas.pm.set_array(data[:-1, :-1].ravel())

--- a/wradvis/mplcanvas.py
+++ b/wradvis/mplcanvas.py
@@ -55,7 +55,6 @@ class MplCanvas(FigureCanvas):
 
         self.create_cities()
 
-
     def create_cities(self):
         self.selected = None
         cities = utils.get_cities_coords()

--- a/wradvis/properties.py
+++ b/wradvis/properties.py
@@ -70,7 +70,14 @@ class MouseBox(DockBox):
         point = self.parent.iwidget.canvas._mouse_position
         self.mousePointXY.setText(
             "({0:d}, {1:d})".format(int(point[0]), int(point[1])))
-        ll = utils.radolan_to_wgs84(point + self.r0)
+
+        # Todo: move this all to utils and use a generalized
+        # ll-retrieving function
+        if self.parent.props.product != 'DX':
+            ll = utils.radolan_to_wgs84(point + self.r0)
+        else:
+            ll = utils.dx_to_wgs84(point)
+
         self.mousePointLL.setText(
             "({0:.2f}, {1:.2f})".format(ll[0], ll[1]))
 

--- a/wradvis/properties.py
+++ b/wradvis/properties.py
@@ -252,6 +252,8 @@ class Properties(QtCore.QObject):
         self.dir = conf["dirs"]["data"]
         self.product = conf["source"]["product"]
         self.parent.iwidget.set_canvas(self.product)
+        self.clim = (conf.get("vis", "cmin"), conf.get("vis", "cmax"))
+        self.parent.iwidget.set_clim(self.clim)
         self.loc = conf.get("source", "loc")
         self.filelist = glob.glob(os.path.join(self.dir, "raa0*{0}*".format(self.loc)))
         self.frames = len(self.filelist)

--- a/wradvis/properties.py
+++ b/wradvis/properties.py
@@ -244,7 +244,7 @@ class Properties(QtCore.QObject):
 
     def update_props(self):
         self.dir = conf["dirs"]["data"]
-        self.filelist = glob.glob(os.path.join(self.dir, "raa01*"))
+        self.filelist = glob.glob(os.path.join(self.dir, "raa00*---bin"))
         self.frames = len(self.filelist)
         self.actualFrame = 0
         self.signal_props_changed.emit()

--- a/wradvis/properties.py
+++ b/wradvis/properties.py
@@ -87,15 +87,9 @@ class SourceBox(DockBox):
         self.hline = QtGui.QFrame()
         self.hline.setFrameShape(QtGui.QFrame.HLine)
         self.hline.setFrameShadow(QtGui.QFrame.Sunken)
-        self.dirname = conf["dirs"]["data"]
+        self.dirname = "None" #conf["dirs"]["data"]
         self.dirLabel = LongLabel(self.dirname)
-        self.props.filelist = sorted(
-            glob.glob(os.path.join(self.dirname, "raa01*.gz")))
-        self.props.frames = len(self.props.filelist)
-        self.props.actualFrame = 0
 
-        # Data source box (control via File menu bar)
-        #self.layout.setContentsMargins(1, 7, 1, 1)
         self.layout.addWidget(LongLabel("Current data directory"), 0, 0, 1, 7)
         self.layout.addWidget(self.dirLabel, 1, 0, 1, 7)
         self.dirLabel.setFixedWidth(200)
@@ -120,7 +114,6 @@ class MediaBox(DockBox):
         # Media Control
         self.data = QtGui.QSlider(QtCore.Qt.Horizontal)
         self.data.setMinimum(1)
-        self.data.setMaximum(self.props.frames)
         self.data.setTickInterval(1)
         self.data.setSingleStep(1)
         self.data.valueChanged.connect(self.update_slider)
@@ -130,14 +123,10 @@ class MediaBox(DockBox):
         self.speed.setTickInterval(10)
         self.speed.setSingleStep(10)
         self.speed.valueChanged.connect(self.speed_changed)
-        self.dateLabel = QtGui.QLabel("Date")#, self)
-        self.dateLabel.setMaximumHeight(10)
-        self.date = QtGui.QLabel("1900-01-01")#, self)
-        self.date.setMaximumHeight(10)
-        self.timeLabel = QtGui.QLabel("Time")#, self)
-        self.timeLabel.setMaximumHeight(10)
-        self.sliderLabel = QtGui.QLabel("00:00")#, self)
-        self.sliderLabel.setMaximumHeight(10)
+        self.dateLabel = QtGui.QLabel("Date")
+        self.date = QtGui.QLabel("1900-01-01")
+        self.timeLabel = QtGui.QLabel("Time")
+        self.sliderLabel = QtGui.QLabel("00:00")
         self.createMediaButtons()
         self.hline0 = QtGui.QFrame()
         self.hline0.setFrameShape(QtGui.QFrame.HLine)
@@ -145,7 +134,6 @@ class MediaBox(DockBox):
         self.hline1 = QtGui.QFrame()
         self.hline1.setFrameShape(QtGui.QFrame.HLine)
         self.hline1.setFrameShadow(QtGui.QFrame.Sunken)
-        # self.mediabox.setContentsMargins(1, 20, 1, 1)
 
         self.layout.addWidget(self.hline0, 0, 0, 1, 7)
         self.layout.addWidget(self.dateLabel, 1, 0, 1, 7)
@@ -160,9 +148,6 @@ class MediaBox(DockBox):
         self.layout.addWidget(self.hline1, 5, 0, 1, 7)
 
         self.props.props_changed.connect(self.update_props)
-
-        print("MediaBox")
-
 
     def createMediaButtons(self):
         iconSize = QtCore.QSize(18, 18)
@@ -261,4 +246,5 @@ class Properties(QtCore.QObject):
         self.dir = conf["dirs"]["data"]
         self.filelist = glob.glob(os.path.join(self.dir, "raa01*"))
         self.frames = len(self.filelist)
+        self.actualFrame = 0
         self.signal_props_changed.emit()

--- a/wradvis/properties.py
+++ b/wradvis/properties.py
@@ -65,8 +65,12 @@ class MouseBox(DockBox):
         # connect to signal
         self.parent.rwidget.rcanvas.mouse_moved.connect(self.mouse_moved)
         self.parent.rwidget.pcanvas.mouse_moved.connect(self.mouse_moved)
+        self.parent.mwidget.rcanvas.mouse_moved.connect(self.mouse_moved)
 
     def mouse_moved(self, event):
+        print(event)
+
+        # todo: check if originating from mpl and adapt self.r0 correctly
         point = self.parent.iwidget.canvas._mouse_position
         self.mousePointXY.setText(
             "({0:d}, {1:d})".format(int(point[0]), int(point[1])))

--- a/wradvis/utils.py
+++ b/wradvis/utils.py
@@ -42,6 +42,9 @@ def get_radolan_origin():
 def read_radolan(f, missing=0, loaddata=True):
     return wrl.io.read_RADOLAN_composite(f, missing=missing, loaddata=loaddata)
 
+def read_dx(f, missing=0, loaddata=True):
+    return wrl.io.readDX(f)
+
 
 def get_cities_coords():
 

--- a/wradvis/utils.py
+++ b/wradvis/utils.py
@@ -9,6 +9,7 @@
 """
 
 import wradlib as wrl
+import numpy as np
 from wradvis.config import conf
 
 
@@ -30,6 +31,31 @@ def radolan_to_wgs84(coords):
                               projection_source=proj_stereo,
                               projection_target=proj_wgs)
     return ll
+
+def dx_to_wgs84(coords):
+
+    # currently works only with radar feldberg
+    #Todo: make this work with all DWD-radars and also with other radars
+    radar = {'name': 'Feldberg', 'wmo': 10908, 'lon': 8.00361,
+             'lat': 47.87361,
+             'alt': 1516.10}
+
+    sitecoords = (radar["lon"], radar["lat"],
+                  radar["alt"])
+
+    proj_radar = wrl.georef.create_osr("aeqd", lat_0=radar["lat"],
+                                       lon_0=radar["lon"])
+
+    radius = wrl.georef.get_earth_radius(radar["lat"], proj_radar)
+
+    lon, lat, height = wrl.georef.polar2lonlatalt_n(coords[1] * 1000,
+                                                    coords[0],
+                                                    0.8,
+                                                    sitecoords,
+                                                    re=radius,
+                                                    ke=4. / 3.)
+
+    return np.hstack((lon, lat))
 
 
 def get_radolan_grid():


### PR DESCRIPTION
- This converts the `sourcebox`, `mediabox` and `mousebox` into separate widgets.
- These widgets are subclassed from `DockWidget` which can have some common layout and properties.
- The box-widgets are added to the main gui
- The MenuBar is now child of the MainWindow and has `File`, `Tools` (the boxes) and `Help`
- The `Properties` are now just an QObject to hold common data.

Also added:
- [x] `DXCanvas` for display of polar data (DWD-DX)
- [x] add lon, lat conversion to `DXCanvas` for correct display in `mousebox`
- [x] PolarImage class, which handles the specific polar transform etc., by creating multiple instances we can have a radar mosaic (with some constraints to projection)
- [x] MPL PolarImage, but only as nonfunctional stub
